### PR TITLE
Remove .fm and add .bo support

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -260,14 +260,6 @@ vc = {
     'extend': 'com',
 }
 
-fm = {
-    'extend': 'com',
-
-    'domain_name': r'Query: \s?(.+)',
-    'creation_date': r'Created: \s?(.+)',
-    'expiration_date': r'Expires: \s?(.+)'
-}
-
 tv = {
     'extend': 'com',
     'domain_name': r'Domain Name: \s?(.+)',

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -331,3 +331,19 @@ kr = {
     'emails': r'[\w.-]+@[\w.-]+\.[\w]{2,4}',
 }
 
+bo = {
+    'extend': None,
+
+    'domain_name': r'Dominio:\s?(.+)',
+    'registrar': None,
+    'registrant': r'TITULAR:?\s{0,}(?:[^\n][\n]?){0,}?\s{0,}Organizacion(?:[^:]{0,}):\s?(.+)',
+    'registrant_cc': r'TITULAR:?\s{0,}(?:[^\n][\n]?){0,}?\s{0,}Pais(?:[^:]{0,}):\s?(.+)',
+
+    'creation_date': r'Fecha de registro:\s?(.+)',
+    'expiration_date': r'Fecha de vencimiento:\s?(.+)',
+    'updated_date': None,
+
+    'name_servers': None,
+    'status': None,
+    'emails': r's/([\w.-]+)(\sen\s)([\w.-]+\.[\w]{2,4})/\1@\3/',
+}


### PR DESCRIPTION
The .fm TLD no longer runs a whois server, so any query attempts will cause an exception. Also added support for .bo
