### PR TITLE
Add .рф tld support

### DIFF
--- a/test.py
+++ b/test.py
@@ -25,6 +25,7 @@ www.google.co.jp
 google.co
 google.de
 yandex.ru
+яндекс.рф
 google.us
 google.eu
 google.me

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -69,6 +69,10 @@ su = {
     'extend': 'ru',
 }
 
+рф = {
+    'extend': 'ru',
+}
+
 lv = {
     'extend': 'ru',
 


### PR DESCRIPTION
Same as .ru

``` python
яндекс.рф
       creation_date    "2009-11-25 00:00:00"
           registrar    "RUCENTER-RF"
       registrant_cc    ""
        name_servers    "{'ns2.yandex.ru', 'ns1.yandex.ru'}"
        last_updated    "None"
                name    "xn--d1acpjx3f.xn--p1ai"
     expiration_date    "2016-11-25 00:00:00"
```
