### PR TITLE
Add host support.

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -34,13 +34,13 @@ def cache_save(cf):
     f.close()
 
 
-def do_query(dl, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
+def do_query(dl, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     k = '.'.join(dl)
     if cache_file: cache_load(cache_file)
     if force or k not in CACHE or CACHE[k][0] < time.time() - CACHE_MAX_AGE:
         CACHE[k] = (
         int(time.time()),
-        _do_whois_query(dl, ignore_returncode),
+        _do_whois_query(dl, host, ignore_returncode),
         )
         if cache_file: cache_save(cache_file)
         if slow_down: time.sleep(slow_down)
@@ -48,11 +48,14 @@ def do_query(dl, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     return CACHE[k][1]
 
 
-def _do_whois_query(dl, ignore_returncode):
+def _do_whois_query(dl, host, ignore_returncode):
     """
         Linux 'whois' command wrapper
     """
-    p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if host == None:
+        p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    else:
+        p = subprocess.Popen(['whois', '-h', host, '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     r = p.communicate()[0]
     if PYTHON_VERSION == 3:
         try:

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -30,7 +30,7 @@ CACHE_FILE = None
 SLOW_DOWN = 0
 
 
-def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
+def query(domain, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     """
         force=1				<bool>		Don't use cache.
         cache_file=<path>	<str>		Use file to store cache not only memory.
@@ -54,7 +54,7 @@ def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     if tld not in TLD_RE.keys(): raise Exception('Unknown TLD: %s\n(all known TLD: %s)' % (tld, list(TLD_RE.keys())))
 
     while 1:
-        pd = do_parse(do_query(d, force, cache_file, slow_down, ignore_returncode), tld)
+        pd = do_parse(do_query(d, host, force, cache_file, slow_down, ignore_returncode), tld)
         if (not pd or not pd['domain_name'][0]) and len(d) > 2:
             d = d[1:]
         else:


### PR DESCRIPTION
do_query now support query with specified host.

This is useful when there is a possibility to switch to another database host (regionally registrant, for example). Equivalent `whois -h whois.nic.ru e2e4.online`
