### PR TITLE
Add travel domain; strip each name server string

### DIFF
--- a/test.py
+++ b/test.py
@@ -59,6 +59,7 @@ nic.ir
 test.technology
 test.im
 nic.co.ua
+nic.travel
 '''
 
 def parse(data):

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -33,7 +33,7 @@ class Domain:
                     x, _ = x.split(' ', 1)
                     x = x.strip(' .')
 
-                self.name_servers.add(x.lower())
+                self.name_servers.add(x.strip().lower())
 
             #----------------------------------
 

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -581,3 +581,13 @@ co_ua = {
     'status': r'Status:\s*(.+)',
     'emails': r'[\w.-]+@[\w.-]+\.[\w]{2,4}',
 }
+
+travel = {
+    'extend': 'com',
+    'domain_name': r'Domain Name: \s?(.+)',
+
+    'creation_date': r'Creation Date: \s?(.+)',
+    'expiration_date': r'Registry Expiry Date: \s?(.+)',
+
+    'name_servers': r'Name Server: *(.+)',
+}


### PR DESCRIPTION
* Add regexps for "travel" domain
* I have found some cases when name servers contains "\r" symbol at the end, so I've added strip() to every name server.