### PR TITLE
Added ability to specify executable path

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -34,13 +34,13 @@ def cache_save(cf):
     f.close()
 
 
-def do_query(dl, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
+def do_query(dl, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0, cmd="whois"):
     k = '.'.join(dl)
     if cache_file: cache_load(cache_file)
     if force or k not in CACHE or CACHE[k][0] < time.time() - CACHE_MAX_AGE:
         CACHE[k] = (
         int(time.time()),
-        _do_whois_query(dl, host, ignore_returncode),
+        _do_whois_query(dl, host, ignore_returncode, cmd=cmd),
         )
         if cache_file: cache_save(cache_file)
         if slow_down: time.sleep(slow_down)
@@ -48,14 +48,14 @@ def do_query(dl, host=None, force=0, cache_file=None, slow_down=0, ignore_return
     return CACHE[k][1]
 
 
-def _do_whois_query(dl, host, ignore_returncode):
+def _do_whois_query(dl, host, ignore_returncode, cmd="whois"):
     """
     Linux 'whois' command wrapper
     """
     if host == None:
-        p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen([cmd, '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     else:
-        p = subprocess.Popen(['whois', '-h', host, '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen([cmd, '-h', host, '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     r = p.communicate()[0]
     if PYTHON_VERSION == 3:
         try:

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -9,11 +9,12 @@ CACHE_FILE = None
 SLOW_DOWN = 0
 
 
-def query(domain, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
+def query(domain, host=None, force=0, cache_file=None, slow_down=0, ignore_returncode=0, cmd="whois"):
     """
     force=1				<bool>		Don't use cache.
     cache_file=<path>	<str>		Use file to store cache not only memory.
     slow_down=0			<int>		Time [s] it will wait after you query WHOIS database. This is useful when there is a limit to the number of requests at a time.
+    cmd='whois'         <str>       The path to the whois binary to use, by default 'whois'
     """
     assert isinstance(domain, str), Exception('`domain` - must be <str>')
     cache_file = cache_file or CACHE_FILE
@@ -37,7 +38,7 @@ def query(domain, host=None, force=0, cache_file=None, slow_down=0, ignore_retur
     if tld not in TLD_RE.keys(): raise Exception("Unknown TLD: {0}\n(all known TLD: {1})".format(tld, list(TLD_RE.keys())))
 
     while 1:
-        pd = do_parse(do_query(d, host, force, cache_file, slow_down, ignore_returncode), tld)
+        pd = do_parse(do_query(d, host, force, cache_file, slow_down, ignore_returncode, cmd=cmd), tld)
         if (not pd or not pd['domain_name'][0]) and len(d) > 2:
             d = d[1:]
         else:


### PR DESCRIPTION
This commit allows the specification of an executable path for the whois binary. This does not effect existing functionality, but allows the use of portable versions of whois, which is incredibly handy for windows usage since without it registry edits have to be made to support this package.