### PR TITLE
Fix .id expiration_date (looks like whois output changed some time ago)

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -721,8 +721,7 @@ studio = {
 }
 
 dot_id = {
-    'extend': 'co_ua',
+    'extend': 'com',
 
-    'registrar': r'Sponsoring Registrar Organization:\s?(.+)',
-    'registrant_cc': r'Sponsoring Registrar Country:\s*(.+)',
+    'expiration_date': r'Registry Expiry Date:\s?(.+)',
 }


### PR DESCRIPTION
Test output:

```
$ python3 test.py google.id
--------------------------------------------------------------------------------
Domain: google.id, host: None
                name	"google.id"
           registrar	"PT Digital Registra Indonesia"
       registrant_cc	""
       creation_date	"2014-04-17 10:39:27"
     expiration_date	"2026-04-17 23:59:59"
        last_updated	"2025-03-22 17:32:34"
        name_servers	"{'ns4.google.com', 'ns2.google.com', 'ns3.google.com', 'ns1.google.com'}"

```